### PR TITLE
Fix #3: prevent server crash when upgrading uncoloured shulker

### DIFF
--- a/src/main/java/com/progwml6/ironshulkerbox/common/items/ShulkerBoxChangerItem.java
+++ b/src/main/java/com/progwml6/ironshulkerbox/common/items/ShulkerBoxChangerItem.java
@@ -141,7 +141,11 @@ public class ShulkerBoxChangerItem extends Item
                     shulkerBoxContents.set(i, shulkerBox.getStackInSlot(i));
                 }
 
-                shulkerBoxColor = shulkerBox.getColor();
+                shulkerBoxColor = ((net.minecraft.block.ShulkerBoxBlock) world.getBlockState(blockPos).getBlock()).getColor();
+
+                if (shulkerBoxColor == null) {
+                    shulkerBoxColor = DyeColor.PURPLE;
+                }
 
                 customName = shulkerBox.getCustomName();
 

--- a/src/main/java/com/progwml6/ironshulkerbox/common/tileentity/IronShulkerBoxTileEntity.java
+++ b/src/main/java/com/progwml6/ironshulkerbox/common/tileentity/IronShulkerBoxTileEntity.java
@@ -390,7 +390,6 @@ public class IronShulkerBoxTileEntity extends LockableLootTileEntity implements 
         return MathHelper.lerp(p_190585_1_, this.progressOld, this.progress);
     }
 
-    @OnlyIn(Dist.CLIENT)
     public DyeColor getColor()
     {
         if (this.needsColorFromWorld)


### PR DESCRIPTION
`getColor` is client-only Dist hence the side violation that causes a
crash. I'm not sure why all of this information needs to be client only.

The only instance is the actual shulker box itself, which is not
client-only (as it's actually in the block instance). Considering the
block has been placed, this is the safest way to get the colour.

Similarly, removed the @DistOnly in your own class as there's no need
for it to be like that, meaning that the `getColor` function can be used
in the other side of the if block with the iron shulker box tile entity.

Finally, if the colour returned is `null` (meaning that it's an
uncoloured shuler box), I've set the default to purple -- which matches
the same colour of the upgraded shulker boxes (although not the colour
of the *actual* purple shulker box).